### PR TITLE
Add makefile for building and pushing docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,33 @@
+GIT_HASH?=$(shell git log --pretty=format:'%h' -n 1)
+DOCKER_NAMESPACE?=quay.io/jaeger-mongodb
+
+BASE_IMAGE?=alpine:3.14.0
+JAEGER_VERSION?=1.23.0
+
 .PHONY: test
 test:
 	go vet ./...
 	go test ./...
+
+.PHONY: clean
+clean::
+	rm jaeger-mongodb
+
+.PHONY: build-linux
+build-linux: clean
+	GOOS=linux go build ./cmd/jaeger-mongodb
+
+.PHONY: docker-build
+docker-build: build-linux
+	for component in collector query ; do \
+  		docker build . -f ./cmd/jaeger-mongodb/Dockerfile.$$component \
+  			--build-arg base_image=$(BASE_IMAGE) \
+  			--build-arg jaeger_version=$(JAEGER_VERSION) \
+  			-t $(DOCKER_NAMESPACE)/jaeger-$$component-mongodb:$(JAEGER_VERSION)-$(GIT_HASH) ; \
+  	done
+
+.PHONY: docker-push
+docker-push: docker-build
+	for component in collector query ; do \
+  		docker push $(DOCKER_NAMESPACE)/jaeger-$$component-mongodb:$(JAEGER_VERSION)-$(GIT_HASH) ; \
+  	done

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 The jaeger-mongodb plugin uses the [grpc] storage architecture to interface with the query and collector services.
 
+## Use
+
+Docker images are provided that contain the jaeger collector and query components with the jaeger mongodb plugin included.
+
+* https://quay.io/repository/jaeger-mongodb/jaeger-collector-mongodb?tab=tags 
+* https://quay.io/repository/jaeger-mongodb/jaeger-query-mongodb?tab=tags
+
+# Development
 
 ## Prerequisites:
 1. Download latest version of [Docker]

--- a/cmd/jaeger-mongodb/Dockerfile.collector
+++ b/cmd/jaeger-mongodb/Dockerfile.collector
@@ -1,6 +1,9 @@
-FROM jaegertracing/jaeger-collector:1.23.0
+ARG base_image
+ARG jaeger_version
 
-FROM alpine
+FROM jaegertracing/jaeger-collector:$jaeger_version
+
+FROM $base_image
 COPY --from=0 /go/bin/collector-linux /go/bin/collector-linux
 COPY jaeger-mongodb /bin/jaeger-mongodb
 

--- a/cmd/jaeger-mongodb/Dockerfile.query
+++ b/cmd/jaeger-mongodb/Dockerfile.query
@@ -1,6 +1,9 @@
-FROM jaegertracing/jaeger-query:1.23.0
+ARG base_image
+ARG jaeger_version
 
-FROM alpine
+FROM jaegertracing/jaeger-query:$jaeger_version
+
+FROM $base_image
 COPY --from=0 /go/bin/query-linux /go/bin/query-linux
 COPY jaeger-mongodb /bin/jaeger-mongodb
 


### PR DESCRIPTION
Pushed images are hosted on quay.

Right now the docker push is being done locally until we can setup github actions to do this automatically.