### PR TITLE
release 1.38.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GIT_HASH?=$(shell git log --pretty=format:'%h' -n 1)
 DOCKER_NAMESPACE?=quay.io/jaeger-mongodb
 
 BASE_IMAGE?=alpine:3.16.2
-JAEGER_VERSION?=1.37.0
+JAEGER_VERSION?=1.38.0
 
 .PHONY: test
 test:


### PR DESCRIPTION
I have pushed the image to `quay.io/jaeger-mongodb/jaeger-query-mongodb:1.38.0-1c9de3b`.