### PR TITLE
fix duration + index for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Docker images are provided that contain the jaeger collector and query component
 | `mongo_database` | Name of the database that stores the trace data                         | traces                            | 
 | `mongo_collection` | Name of the collection in `mongo_database`                              | spans                             |
 | `mongo_timeout_duration` | The timeout duration for commands sent to mongo                         | 5s                                |
-| `mongo_span_ttl_duration` | The duration where the trace data remains in the database               | 14d                               |
+| `mongo_span_ttl_duration` | The duration where the trace data remains in the database               | 336h                              |
 | `otel_tracing_ratio` | Ratio of traces to sample 0.0 to 1.0. Tracing is disabled by default    | 0.0                               |
 | `otel_exporter_endpoint` | Exporter endpoint                                                       | http://localhost:14268/api/traces |
 

--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -1,5 +1,5 @@
 mongo_url: "mongodb://localhost:27017"
 mongo_database: traces
 mongo_collection: spans
-mongo_span_ttl_duration: "14d"
+mongo_span_ttl_duration: "336h"
 otel_tracing_ratio: 1.0

--- a/internal/jaeger-mongodb/config.go
+++ b/internal/jaeger-mongodb/config.go
@@ -44,7 +44,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 	v.SetDefault(mongoDatabase, "traces")
 	v.SetDefault(mongoCollection, "spans")
 	v.SetDefault(mongoTimeoutDuration, "5s")
-	v.SetDefault(mongoSpanTTLDuration, "14d")
+	v.SetDefault(mongoSpanTTLDuration, "336h")
 	v.SetDefault(otelTracingRatio, 0.0) // tracing is disabled by default
 	v.SetDefault(otelExporterEndpoint, "http://localhost:14268/api/traces")
 

--- a/internal/jaeger-mongodb/reader.go
+++ b/internal/jaeger-mongodb/reader.go
@@ -330,11 +330,7 @@ func (s *SpanReader) findTraceIDs(ctx context.Context, query *spanstore.TraceQue
 	// Filtering by concatenation of tags.
 	tags_array := bson.A{}
 	for k, v := range query.Tags {
-		q := bson.M{
-			"tags.key":   k,
-			"tags.value": v,
-		}
-		tags_array = append(tags_array, q)
+		tags_array = append(tags_array, bson.M{"tags": bson.M{"$elemMatch": bson.M{"key": k, "value": v}}})
 	}
 	if len(tags_array) != 0 {
 		filter["$and"] = tags_array


### PR DESCRIPTION
* Fix the duration for the TTL index. `14d` is not supported and resolves to 0.
* Add index for tags and query for tags more efficiently.