### PR TITLE
findTracesIDs. Don't project _id to be able to make a covered query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GIT_HASH?=$(shell git log --pretty=format:'%h' -n 1)
 DOCKER_NAMESPACE?=quay.io/jaeger-mongodb
 
+GO_BASE_IMAGE?=golang:1.19
 BASE_IMAGE?=alpine:3.16.2
 JAEGER_VERSION?=1.44.0
 
@@ -15,15 +16,15 @@ clean::
 
 .PHONY: build-linux
 build-linux: clean
-	GOOS=linux GOARCH=amd64 go build ./cmd/jaeger-mongodb
+	go build ./cmd/jaeger-mongodb
 
 .PHONY: docker-build
-docker-build: build-linux
+docker-build:
 	for component in collector query ; do \
-  		docker buildx build . -f ./cmd/jaeger-mongodb/Dockerfile.$$component \
+  		docker buildx build . -f ./cmd/jaeger-mongodb/Dockerfile.$$component --no-cache \
   			--build-arg base_image=$(BASE_IMAGE) \
+  			--build-arg go_base_image=$(GO_BASE_IMAGE) \
   			--build-arg jaeger_version=$(JAEGER_VERSION) \
-  			--platform linux/amd64 \
   			-t $(DOCKER_NAMESPACE)/jaeger-$$component-mongodb:$(JAEGER_VERSION)-$(GIT_HASH) ; \
   	done
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-linux: clean
 .PHONY: docker-build
 docker-build:
 	for component in collector query ; do \
-  		docker buildx build . -f ./cmd/jaeger-mongodb/Dockerfile.$$component --no-cache \
+  		docker buildx build . -f ./cmd/jaeger-mongodb/Dockerfile.$$component\
   			--build-arg base_image=$(BASE_IMAGE) \
   			--build-arg go_base_image=$(GO_BASE_IMAGE) \
   			--build-arg jaeger_version=$(JAEGER_VERSION) \

--- a/cmd/jaeger-mongodb/Dockerfile.collector
+++ b/cmd/jaeger-mongodb/Dockerfile.collector
@@ -1,11 +1,20 @@
 ARG base_image
+ARG go_base_image
 ARG jaeger_version
 
-FROM jaegertracing/jaeger-collector:$jaeger_version
+FROM jaegertracing/jaeger-collector:$jaeger_version as jaeger
 
-FROM $base_image
-COPY --from=0 /go/bin/collector-linux /go/bin/collector-linux
-COPY jaeger-mongodb /bin/jaeger-mongodb
+FROM $go_base_image as builder
+WORKDIR /app/
+COPY go.mod go.sum /app
+RUN go mod download
+COPY . /app
+RUN CGO_ENABLED=0 GOOS=linux go build  ./cmd/jaeger-mongodb
+
+FROM $base_image as runner
+
+COPY --from=jaeger /go/bin/collector-linux /go/bin/collector-linux
+COPY --from=builder /app/jaeger-mongodb /bin/jaeger-mongodb
 
 ENV SPAN_STORAGE_TYPE grpc-plugin
 ENV GRPC_STORAGE_PLUGIN_BINARY /bin/jaeger-mongodb

--- a/cmd/jaeger-mongodb/Dockerfile.query
+++ b/cmd/jaeger-mongodb/Dockerfile.query
@@ -1,11 +1,20 @@
 ARG base_image
+ARG go_base_image
 ARG jaeger_version
 
-FROM jaegertracing/jaeger-query:$jaeger_version
+FROM jaegertracing/jaeger-query:$jaeger_version as jaeger
 
-FROM $base_image
-COPY --from=0 /go/bin/query-linux /go/bin/query-linux
-COPY jaeger-mongodb /bin/jaeger-mongodb
+FROM $go_base_image as builder
+WORKDIR /app/
+COPY go.mod go.sum /app
+RUN go mod download
+COPY . /app
+RUN CGO_ENABLED=0 GOOS=linux go build  ./cmd/jaeger-mongodb
+
+FROM $base_image as runner
+
+COPY --from=jaeger /go/bin/query-linux /go/bin/query-linux
+COPY --from=builder /app/jaeger-mongodb /bin/jaeger-mongodb
 
 ENV SPAN_STORAGE_TYPE grpc-plugin
 ENV GRPC_STORAGE_PLUGIN_BINARY /bin/jaeger-mongodb

--- a/cmd/jaeger-mongodb/main.go
+++ b/cmd/jaeger-mongodb/main.go
@@ -128,6 +128,16 @@ func createIndexes(ctx context.Context, logger hclog.Logger, collection *mongo.C
 			Name: String("ServiceNameAndOperationsIndex"),
 		},
 	}
+	serviceNameTraceIdIndex := mongo.IndexModel{
+		Keys: bson.D{
+			bson.E{Key: "process.serviceName", Value: 1},
+			bson.E{Key: "startTime", Value: -1},
+			bson.E{Key: "traceID", Value: 1},
+		},
+		Options: &options.IndexOptions{
+			Name: String("ServiceNameTraceIdIndex"),
+		},
+	}
 
 	traceIDIndex := mongo.IndexModel{
 		Keys: bson.M{"traceID": 1},
@@ -154,6 +164,7 @@ func createIndexes(ctx context.Context, logger hclog.Logger, collection *mongo.C
 		[]mongo.IndexModel{
 			ttlIndex,
 			serviceNameIndex,
+			serviceNameTraceIdIndex,
 			traceIDIndex,
 			tagsIndex,
 		},

--- a/internal/jaeger-mongodb/reader.go
+++ b/internal/jaeger-mongodb/reader.go
@@ -288,6 +288,9 @@ func (s *SpanReader) fetchTracesById(ctx context.Context, ids []string) (map[str
 			return nil, err
 		}
 		logs, err := s.convertLogs(ms.Logs)
+		if err != nil {
+			return nil, err
+		}
 
 		s := model.Span{
 			TraceID:       tId,
@@ -516,7 +519,7 @@ func (s *SpanReader) convertLogs(logs []Log) ([]model.Log, error) {
 			return []model.Log{}, err
 		}
 		convertedLog := model.Log{
-			Timestamp: time.Unix(int64(log.Timestamp), 0),
+			Timestamp: time.UnixMilli(int64(log.Timestamp)),
 			Fields:    fields,
 		}
 		convertedLogs[i] = convertedLog

--- a/internal/jaeger-mongodb/reader.go
+++ b/internal/jaeger-mongodb/reader.go
@@ -364,7 +364,7 @@ func (s *SpanReader) findTraceIDs(ctx context.Context, query *spanstore.TraceQue
 	}
 
 	opts := options.FindOptions{
-		Projection: bson.D{{"traceID", 1}},
+		Projection: bson.D{{"traceID", 1}, {"_id", 0}},
 		Sort:       bson.D{{"startTime", -1}},
 	}
 

--- a/internal/jaeger-mongodb/reader.go
+++ b/internal/jaeger-mongodb/reader.go
@@ -287,6 +287,7 @@ func (s *SpanReader) fetchTracesById(ctx context.Context, ids []string) (map[str
 		if err != nil {
 			return nil, err
 		}
+		logs, err := s.convertLogs(ms.Logs)
 
 		s := model.Span{
 			TraceID:       tId,
@@ -296,12 +297,12 @@ func (s *SpanReader) fetchTracesById(ctx context.Context, ids []string) (map[str
 			StartTime:     ms.StartTime,
 			Duration:      model.MicrosecondsAsDuration(uint64(ms.Duration)),
 			Tags:          tags,
-			Logs:          []model.Log{}, // TODO(dmichel): implement
+			Logs:          logs,
 			Process: &model.Process{
 				ServiceName: ms.Process.ServiceName,
 				Tags:        pTags,
 			},
-			Warnings: []string{}, // TODO(dmichel): implement
+			Warnings: ms.Warnings,
 		}
 
 		tracesMap[ms.TraceID].Spans = append(tracesMap[ms.TraceID].Spans, &s)
@@ -505,4 +506,20 @@ func (s *SpanReader) convertKeyValue(tag *KeyValue) (model.KeyValue, error) {
 		return model.Float64(tag.Key, value), nil
 	}
 	return model.KeyValue{}, fmt.Errorf("not a valid ValueType string %s", string(tag.Type))
+}
+
+func (s *SpanReader) convertLogs(logs []Log) ([]model.Log, error) {
+	convertedLogs := make([]model.Log, len(logs))
+	for i, log := range logs {
+		fields, err := s.convertKeyValues(log.Fields)
+		if err != nil {
+			return []model.Log{}, err
+		}
+		convertedLog := model.Log{
+			Timestamp: time.Unix(int64(log.Timestamp), 0),
+			Fields:    fields,
+		}
+		convertedLogs[i] = convertedLog
+	}
+	return convertedLogs, nil
 }

--- a/internal/jaeger-mongodb/writer.go
+++ b/internal/jaeger-mongodb/writer.go
@@ -34,8 +34,8 @@ func (s *SpanWriter) WriteSpan(ctx context.Context, span *model.Span) error {
 		ProcessID:     span.ProcessID,
 		Process:       convertProcess(span.Process),
 		Tags:          convertKeyValues(span.Tags),
-		//Logs:          nil,
-		Warnings: span.Warnings,
+		Logs:          convertLogs(span.Logs),
+		Warnings:      span.Warnings,
 	}
 	b, err := bson.Marshal(mSpan)
 
@@ -88,4 +88,15 @@ func convertKeyValue(kv model.KeyValue) KeyValue {
 		Type:  ValueType(strings.ToLower(kv.VType.String())),
 		Value: kv.AsString(),
 	}
+}
+func convertLogs(logs []model.Log) []Log {
+	convertedLogs := make([]Log, 0)
+	for _, log := range logs {
+		convertedLog := Log{
+			Timestamp: uint64(log.Timestamp.Unix()),
+			Fields:    convertKeyValues(log.Fields),
+		}
+		convertedLogs = append(convertedLogs, convertedLog)
+	}
+	return convertedLogs
 }

--- a/internal/jaeger-mongodb/writer.go
+++ b/internal/jaeger-mongodb/writer.go
@@ -93,7 +93,7 @@ func convertLogs(logs []model.Log) []Log {
 	convertedLogs := make([]Log, 0)
 	for _, log := range logs {
 		convertedLog := Log{
-			Timestamp: uint64(log.Timestamp.Unix()),
+			Timestamp: uint64(log.Timestamp.UnixMilli()),
 			Fields:    convertKeyValues(log.Fields),
 		}
 		convertedLogs = append(convertedLogs, convertedLog)


### PR DESCRIPTION
I've noticed the findTraceIDs query is not being able to run as a covered query due to  the _id field being always returned in queries. I've modified the projection to not include the _id field. This allows this query to run as a covered query which vastly improves performance. Additionally to make this work,  I've added a new index that is used by this query

As a baseline, getting 2 days of traces for a particular service took more than 20 seconds to complete ( if completed at all since timeouts start to occur ) with this change it runs in less than 10 seconds