### PR TITLE
CLOUDP-189305: Update jaeger to 1.48.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GIT_HASH?=$(shell git log --pretty=format:'%h' -n 1)
 DOCKER_NAMESPACE?=quay.io/jaeger-mongodb
 
 BASE_IMAGE?=alpine:3.16.2
-JAEGER_VERSION?=1.44.0
+JAEGER_VERSION?=1.48.0
 
 .PHONY: test
 test:


### PR DESCRIPTION
Update jaeger to 1.48.0 (see [releases](https://github.com/jaegertracing/jaeger/releases)).